### PR TITLE
Add support for concepts from the api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>mdrclient</artifactId>
-  <version>3.0.0</version>
+  <version>3.1.0-SNAPSHOT</version>
 
   <name>Samply MDR Client</name>
   <description>Samply.Common.MDRClient is a Java library which provides convenient methods to access

--- a/src/de/samply/common/mdrclient/domain/Concept.java
+++ b/src/de/samply/common/mdrclient/domain/Concept.java
@@ -1,0 +1,154 @@
+package de.samply.common.mdrclient.domain;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Concept of a data element.
+ */
+public class Concept {
+
+  /**
+   * The concept system.
+   */
+  @SerializedName("concept_system")
+  private String conceptSystem;
+
+  /**
+   * The concept source.
+   */
+  @SerializedName("concept_source")
+  private Integer conceptSource;
+
+  /**
+   * The concept version.
+   */
+  @SerializedName("concept_version")
+  private String conceptVersion;
+
+  /**
+   * The concept term.
+   */
+  @SerializedName("concept_term")
+  private String conceptTerm;
+
+  /**
+   * The concept text.
+   */
+  @SerializedName("concept_text")
+  private String conceptText;
+
+  /**
+   * The concept linktype.
+   */
+  @SerializedName("concept_linktype")
+  private String conceptLinktype;
+
+  /**
+   * Get the system of the concept.
+   *
+   * @return The concept system
+   */
+  public final String getConceptSystem() {
+    return conceptSystem;
+  }
+
+  /**
+   * Set the system of the concept.
+   *
+   * @param conceptSystem The concept system
+   */
+  public final void setConceptSystem(final String conceptSystem) {
+    this.conceptSystem = conceptSystem;
+  }
+
+  /**
+   * Get the source of the concept.
+   *
+   * @return The concept source
+   */
+  public final Integer getConceptSource() {
+    return conceptSource;
+  }
+
+  /**
+   * Set the source of the concept.
+   *
+   * @param conceptSource The concept source
+   */
+  public final void setConceptSource(final Integer conceptSource) {
+    this.conceptSource = conceptSource;
+  }
+
+  /**
+   * Get the version of the concept.
+   *
+   * @return The concept version
+   */
+  public final String getConceptVersion() {
+    return conceptVersion;
+  }
+
+  /**
+   * Set the version of the concept.
+   *
+   * @param conceptVersion The concept version
+   */
+  public final void setConceptVersion(final String conceptVersion) {
+    this.conceptVersion = conceptVersion;
+  }
+
+  /**
+   * Get the term of the concept.
+   *
+   * @return The concept term
+   */
+  public final String getConceptTerm() {
+    return conceptTerm;
+  }
+
+  /**
+   * Set the term of the concept.
+   *
+   * @param conceptTerm The concept term
+   */
+  public final void setConceptTerm(final String conceptTerm) {
+    this.conceptTerm = conceptTerm;
+  }
+
+  /**
+   * Get the text of the concept.
+   *
+   * @return The concept text
+   */
+  public final String getConceptText() {
+    return conceptText;
+  }
+
+  /**
+   * Set the text of the concept.
+   *
+   * @param conceptText The concept text
+   */
+  public final void setConceptText(final String conceptText) {
+    this.conceptText = conceptText;
+  }
+
+  /**
+   * Get the linktype of the concept.
+   *
+   * @return The concept linktype
+   */
+  public final String getConceptLinktype() {
+    return conceptLinktype;
+  }
+
+  /**
+   * Set the linktype of the concept.
+   *
+   * @param conceptLinktype The concept linktype
+   */
+  public final void setConceptLinktype(final String conceptLinktype) {
+    this.conceptLinktype = conceptLinktype;
+  }
+
+}

--- a/src/de/samply/common/mdrclient/domain/DataElement.java
+++ b/src/de/samply/common/mdrclient/domain/DataElement.java
@@ -10,6 +10,7 @@ public class DataElement {
   private Identification identification;
   private List<Slot> slots;
   private List<Designation> designations;
+  private List<Concept> concepts;
   private Validations validation;
 
   public Identification getIdentification() {
@@ -34,6 +35,14 @@ public class DataElement {
 
   public void setDesignations(List<Designation> designations) {
     this.designations = designations;
+  }
+
+  public List<Concept> getConcepts() {
+    return concepts;
+  }
+
+  public void setConcepts(List<Concept> concepts) {
+    this.concepts = concepts;
   }
 
   public Validations getValidation() {

--- a/src/site/markdown/changelog.md
+++ b/src/site/markdown/changelog.md
@@ -3,12 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
-
+## [3.1.0 - Unreleased]
+### Added
+- Support for *concepts*
 ## [3.0.0 - 2020-11-04]
 - Github release
 ### Changed
 - Samply parent 11.1.0
-## Added
+### Added
 - Github Actions
 - Google Code Style
 


### PR DESCRIPTION
**What's in the PR**
In recent versions of Samply MDR the dataelement was extended with *concepts* which are also exported using the REST API. Unfortunately the client library is not able to utilize such concepts because the required model classes are not defined.
This PR adds those classes and therefore the support for concepts.

**How to test manually**
* Define a concept for a dataelement in Samply MDR
* Fetch the dataelement using the client library
* Access the list of Concepts by using the method `getConcepts()` on the dataelement
